### PR TITLE
Prompt for save location when exporting CSV

### DIFF
--- a/colorimetry explorer.html
+++ b/colorimetry explorer.html
@@ -427,8 +427,27 @@
       '#911eb4','#46f0f0','#f032e6','#d2f53c','#fabebe',
       '#008080','#e6beff','#aa6e28','#800000','#aaffc3'
     ];
-    function download(filename, text) {
-      const blob = new Blob([text], {type:'text/plain'});
+    async function download(filename, text) {
+      if (window.showSaveFilePicker) {
+        try {
+          const handle = await window.showSaveFilePicker({
+            suggestedName: filename,
+            types: [{
+              description: 'CSV Files',
+              accept: {'text/csv': ['.csv']}
+            }]
+          });
+          const writable = await handle.createWritable();
+          await writable.write(text);
+          await writable.close();
+        } catch (err) {
+          if (err.name !== 'AbortError') {
+            console.error('Error saving file', err);
+          }
+        }
+        return;
+      }
+      const blob = new Blob([text], {type:'text/csv'});
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;


### PR DESCRIPTION
## Summary
- allow users to choose file name and location when exporting CSV by using the File System Access API if available
- fall back to existing automatic download with a predefined filename for unsupported browsers

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')


------
https://chatgpt.com/codex/tasks/task_e_68bab48ecef48326861c72a621599ff7