### PR TITLE
Ensure save works on first click

### DIFF
--- a/colorimetry explorer.html
+++ b/colorimetry explorer.html
@@ -524,12 +524,12 @@
           const writable = await handle.createWritable();
           await writable.write(blob);
           await writable.close();
+          return; // successfully saved using File System Access API
         } catch (err) {
-          if (err.name !== 'AbortError') {
-            console.error('Error saving file', err);
-          }
+          if (err.name === 'AbortError') return; // user cancelled
+          console.error('Error saving file', err);
+          // fall through to anchor download fallback
         }
-        return;
       }
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- fall back to traditional anchor download if File System Access API save fails

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be8fd6b3908326a87b642a2248b40b